### PR TITLE
Fix unzip problem

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
             "name": "Attach to Remote",
             "address": "127.0.0.1",
             "port": 9229,
-            "localRoot": "${workspaceFolder}"
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "${workspaceFolder}"
         },
         {
             "name": "Unit Tests",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfdx-codescan-plugin",
   "description": "Run CodeScan or SonarQube jobs from sfdx",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Ben van Klinken @ustramooner",
   "bugs": "https://github.com/VillageChief/sfdx-codescan-plugin/issues",
   "dependencies": {

--- a/src/commands/codescan/run.ts
+++ b/src/commands/codescan/run.ts
@@ -235,7 +235,7 @@ export default class Run extends SfdxCommand {
           this.ux.stopSpinner('Failed to download ' + scannerUrl);
           reject('Failed to download ' + scannerUrl);
         })
-        .pipe(unzip.Extract({ path: this.codescanPath}).on('close', () => {
+        .pipe(unzip.Extract({ path: this.codescanPath}).on('finish', () => {
           this.ux.stopSpinner();
           if (!fs.existsSync(sonarScannerPath)) {
             throw new SfdxError(messages.getMessage('errorSonarScannerPathDoestExist', [sonarScannerPath]));


### PR DESCRIPTION
The `close` event is fired twice for `unzip.Extract` call - I think for readable and writable streams. And it breaks the Promise execution.

So I've changed to `finish` event, not it works well.