### PR TITLE
Feature server override

### DIFF
--- a/messages/codescan.json
+++ b/messages/codescan.json
@@ -3,6 +3,7 @@
 
   "qualitygateCommandDescription": "Waits for SonarQube quality gate to complete and returns result.",
   "serverFlagDescription": " URL of you SonarQube/CodeScan Cloud server. Defaults to CodeScan Cloud (https://app.codescan.io)",
+  "serverOverrideFlagDescription": "Optional URL of you SonarQube/CodeScan Cloud server that overrides any urls returned from SonarQube.",
   "organizationFlagDescription": "CodeScan Organization ID. Only required when connecting to CodeScan Cloud.",
   "projectKeyFlagDescription": "sonar.projectKey - the project key to create.",
   "tokenFlagDescription": "SonarQube token. The preferred method of authentication.",

--- a/src/commands/codescan/run.ts
+++ b/src/commands/codescan/run.ts
@@ -36,7 +36,7 @@ export default class Run extends SfdxCommand {
   protected static flagsConfig = {
     // flag with a value (-n, --name=VALUE)
     server: flags.string({char: 's', description: messages.getMessage('serverFlagDescription')}),
-    serverOverride: flags.string({char: 's', description: messages.getMessage('serverOverrideFlagDescription')}),
+    serverOverride: flags.string({description: messages.getMessage('serverOverrideFlagDescription')}),
     organization: flags.string({char: 'o', description: messages.getMessage('organizationFlagDescription')}),
 
     projectkey: flags.string({char: 'k', description: messages.getMessage('projectKeyFlagDescription')}),

--- a/src/commands/codescan/run.ts
+++ b/src/commands/codescan/run.ts
@@ -36,6 +36,7 @@ export default class Run extends SfdxCommand {
   protected static flagsConfig = {
     // flag with a value (-n, --name=VALUE)
     server: flags.string({char: 's', description: messages.getMessage('serverFlagDescription')}),
+    serverOverride: flags.string({char: 's', description: messages.getMessage('serverOverrideFlagDescription')}),
     organization: flags.string({char: 'o', description: messages.getMessage('organizationFlagDescription')}),
 
     projectkey: flags.string({char: 'k', description: messages.getMessage('projectKeyFlagDescription')}),
@@ -201,8 +202,9 @@ export default class Run extends SfdxCommand {
     const qgtimeout = _this.flags.qgtimeout ? parseInt(_this.flags.qgtimeout, 10) : 300;
     const end = new Date().getTime() + (qgtimeout * 1000);
     const auth = _this.flags.token ? _this.flags.token : (_this.flags.username && _this.flags.password ? {user: _this.flags.username, pass: _this.flags.password} : {});
+    const serverOverride = _this.flags.serverOverride;
     return new Promise((resolve, reject) => {
-      pollQualityGate(auth, end, sonarWorkingDir, 2000, resolve, reject);
+      pollQualityGate(auth, end, sonarWorkingDir, 2000, serverOverride, resolve, reject);
     });
   }
 


### PR DESCRIPTION
Follow up from #27.

This implements a `--serverOverride` flag such that the defined value will override the `serverUrl` that's returned by sonarqube in the `report-task.txt` file. This is important for cases where the server is proxied. See the original issue for more information.

Thanks
Ryan.